### PR TITLE
feat: API request validation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "express": "^4.18.2",
+        "express-validator": "^7.0.1",
         "typescript": "^4.9.5"
       },
       "devDependencies": {
@@ -2571,6 +2572,18 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+      "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3936,6 +3949,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5401,6 +5419,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "^4.18.2",
+    "express-validator": "^7.0.1",
     "typescript": "^4.9.5"
   },
   "devDependencies": {

--- a/backend/src/controllers/todoController.ts
+++ b/backend/src/controllers/todoController.ts
@@ -4,9 +4,9 @@ import type TodoItemType from "../types/TodoItemType";
 type CreateReqBody = Omit<TodoItemType, "id">;
 
 type UpdateReqParams = { id: string };
-type UpdateReqBody = Omit<TodoItemType, "id">;
+type UpdateReqBody = CreateReqBody;
 
-type DeleteReqParams = { id: string };
+type DeleteReqParams = UpdateReqParams;
 
 const listTodos: RequestHandler = (req, res) => {
   res.send("List To-Dos");

--- a/backend/src/middlewares/todoValidator.ts
+++ b/backend/src/middlewares/todoValidator.ts
@@ -8,9 +8,10 @@ const validationHandler = (): RequestHandler => (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
     const firstError = errors.array()[0];
-    return res.status(400).json({ message: firstError.msg });
+    res.status(400).json({ message: firstError.msg });
+  } else {
+    next();
   }
-  next();
 };
 
 const createTodo: RequestHandler[] = [

--- a/backend/src/middlewares/todoValidator.ts
+++ b/backend/src/middlewares/todoValidator.ts
@@ -1,0 +1,29 @@
+import { body, validationResult } from "express-validator";
+import type { RequestHandler } from "express";
+
+const nameValidationRule = (): RequestHandler =>
+  body("name").notEmpty().escape().withMessage("name is required");
+
+const validationHandler = (): RequestHandler => (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    const firstError = errors.array()[0];
+    return res.status(400).json({ message: firstError.msg });
+  }
+  next();
+};
+
+const createTodo: RequestHandler[] = [
+  nameValidationRule(),
+  validationHandler(),
+];
+
+const updateTodo: RequestHandler[] = [
+  nameValidationRule(),
+  validationHandler(),
+];
+
+export default {
+  createTodo,
+  updateTodo,
+};

--- a/backend/src/routes/todoRoute.ts
+++ b/backend/src/routes/todoRoute.ts
@@ -1,13 +1,14 @@
 import express from "express";
 import todoController from "../controllers/todoController";
+import todoValidator from "../middlewares/todoValidator";
 
 const router = express.Router();
 
 router.get("/", todoController.listTodos);
 
-router.post("/", todoController.createTodo);
+router.post("/", todoValidator.createTodo, todoController.createTodo);
 
-router.put("/:id", todoController.updateTodo);
+router.put("/:id", todoValidator.updateTodo, todoController.updateTodo);
 
 router.delete("/:id", todoController.deleteTodo);
 

--- a/backend/src/utils/validatorTester.ts
+++ b/backend/src/utils/validatorTester.ts
@@ -1,0 +1,17 @@
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+
+const validatorTester = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  ...validators: Array<RequestHandler>
+) => {
+  for (let i = 0; i < validators.length - 1; i++) {
+    // Need to await here because middlewares from "express-validator" are async functions
+    await validators[i](req, res, next);
+  }
+
+  validators[validators.length - 1](req, res, next);
+};
+
+export default validatorTester;

--- a/backend/tests/middlewares/todoValidator.test.ts
+++ b/backend/tests/middlewares/todoValidator.test.ts
@@ -1,0 +1,77 @@
+import todoValidator from "../../src/middlewares/todoValidator";
+import validatorTester from "../../src/utils/validatorTester";
+import type { Request, Response, NextFunction } from "express";
+
+describe("todoValidator", () => {
+  let mockRequest: Request;
+  let mockResponse: Response;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    mockRequest = {} as Request;
+
+    mockResponse = {} as Response;
+    mockResponse.status = jest.fn().mockReturnThis();
+    mockResponse.json = jest.fn().mockReturnThis();
+
+    mockNext = jest.fn();
+  });
+
+  xit("should respond 400 with error msg if creating To-Do with name missing", async () => {
+    mockRequest.body = {};
+
+    await validatorTester(
+      mockRequest,
+      mockResponse,
+      mockNext,
+      ...todoValidator.createTodo
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      message: "name is required",
+    });
+  });
+
+  xit("should proceed to next middleware if creating To-Do with name", async () => {
+    mockRequest.body = { name: "Test" };
+
+    await validatorTester(
+      mockRequest,
+      mockResponse,
+      mockNext,
+      ...todoValidator.createTodo
+    );
+
+    expect(mockNext).toHaveBeenCalledTimes(todoValidator.createTodo.length);
+  });
+
+  it("should respond 400 with error msg if updating To-Do with name missing", async () => {
+    mockRequest.body = {};
+
+    await validatorTester(
+      mockRequest,
+      mockResponse,
+      mockNext,
+      ...todoValidator.updateTodo
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      message: "name is required",
+    });
+  });
+
+  it("should proceed to next middleware if updating To-Do with name", async () => {
+    mockRequest.body = { name: "Test" };
+
+    await validatorTester(
+      mockRequest,
+      mockResponse,
+      mockNext,
+      ...todoValidator.updateTodo
+    );
+
+    expect(mockNext).toHaveBeenCalledTimes(todoValidator.updateTodo.length);
+  });
+});


### PR DESCRIPTION
Use `express-validator` to validate the request. Currently only validate the `name` field to be present in the body of `POST` & `PUT` requests.