### PR TITLE
feat: validate id existence

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,10 @@
 import express from "express";
+import type { ErrorRequestHandler } from "express";
 import todoRouter from "./routes/todoRoute";
+
+const jsonErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
+  res.status(500).send({ message: err.message });
+};
 
 const app = express();
 
@@ -10,5 +15,11 @@ app.get("/", (req, res) => {
 });
 
 app.use("/todo", todoRouter);
+
+app.get("*", (req, res) => {
+  res.status(404).json({});
+});
+
+app.use(jsonErrorHandler);
 
 export default app;

--- a/backend/src/controllers/todoController.ts
+++ b/backend/src/controllers/todoController.ts
@@ -31,6 +31,9 @@ const createTodo: RequestHandler<{}, CreateResBody, CreateReqBody> = async (
   const { name } = req.body;
   try {
     const todoCreated = await todoServices.createTodo(name);
+    if (!todoCreated) {
+      throw new Error("Something went wrong when creating To-Do");
+    }
     res.status(201).json(todoCreated);
   } catch (error) {
     next(error);
@@ -46,6 +49,9 @@ const updateTodo: RequestHandler<
   const { name } = req.body;
   try {
     const todoUpdated = await todoServices.updateTodo(id, name);
+    if (!todoUpdated) {
+      throw new Error("Something went wrong when updating To-Do");
+    }
     res.json(todoUpdated);
   } catch (error) {
     next(error);
@@ -60,6 +66,9 @@ const deleteTodo: RequestHandler<DeleteReqParams, DeleteResBody> = async (
   const { id } = req.params;
   try {
     const todoDeleted = await todoServices.deleteTodo(id);
+    if (!todoDeleted) {
+      throw new Error("Something went wrong when deleting To-Do");
+    }
     res.json(todoDeleted);
   } catch (error) {
     next(error);

--- a/backend/src/middlewares/todoValidator.ts
+++ b/backend/src/middlewares/todoValidator.ts
@@ -1,14 +1,42 @@
-import { body, validationResult } from "express-validator";
-import type { RequestHandler } from "express";
+import { body, param, validationResult } from "express-validator";
+import type { ValidationChain, ValidationError } from "express-validator";
+import type { RequestHandler, Response } from "express";
+import todoServices from "../services/todoServices";
 
-const nameValidationRule = (): RequestHandler =>
-  body("name").notEmpty().escape().withMessage("name is required");
+const nameValidationRule = (): ValidationChain =>
+  body("name")
+    .notEmpty()
+    .escape()
+    .withMessage("name is required")
+    .bail({ level: "request" });
+
+const idValidationRule = (): ValidationChain =>
+  param("id")
+    .escape()
+    .custom(async (id: string) => {
+      const result = await todoServices.getTodo(id);
+      if (!result) {
+        throw new Error(`id '${id}' does not exist`);
+      }
+    })
+    .bail({ level: "request" });
+
+const isIdNotExistError = (error: ValidationError): boolean =>
+  error.type === "field" && error.location === "params" && error.path === "id";
+
+const processError = (error: ValidationError, res: Response) => {
+  if (isIdNotExistError(error)) {
+    res.status(404).json({ message: error.msg });
+  } else {
+    res.status(400).json({ message: error.msg });
+  }
+};
 
 const validationHandler = (): RequestHandler => (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
     const firstError = errors.array()[0];
-    res.status(400).json({ message: firstError.msg });
+    processError(firstError, res);
   } else {
     next();
   }
@@ -21,10 +49,14 @@ const createTodo: RequestHandler[] = [
 
 const updateTodo: RequestHandler[] = [
   nameValidationRule(),
+  idValidationRule(),
   validationHandler(),
 ];
+
+const deleteTodo: RequestHandler[] = [idValidationRule(), validationHandler()];
 
 export default {
   createTodo,
   updateTodo,
+  deleteTodo,
 };

--- a/backend/src/routes/todoRoute.ts
+++ b/backend/src/routes/todoRoute.ts
@@ -10,6 +10,6 @@ router.post("/", todoValidator.createTodo, todoController.createTodo);
 
 router.put("/:id", todoValidator.updateTodo, todoController.updateTodo);
 
-router.delete("/:id", todoController.deleteTodo);
+router.delete("/:id", todoValidator.deleteTodo, todoController.deleteTodo);
 
 export default router;

--- a/backend/src/services/todoServices.ts
+++ b/backend/src/services/todoServices.ts
@@ -19,7 +19,7 @@ const getTodo = async (id: string): Promise<TodoItemType | undefined> => {
   return rows[0];
 };
 
-const createTodo = async (name: string): Promise<TodoItemType> => {
+const createTodo = async (name: string): Promise<TodoItemType | undefined> => {
   const { rows } = await pool.query<TodoItemType, [string]>(
     "INSERT INTO todo (name) VALUES ($1) RETURNING id::text, name",
     [name]
@@ -27,7 +27,10 @@ const createTodo = async (name: string): Promise<TodoItemType> => {
   return rows[0];
 };
 
-const updateTodo = async (id: string, name: string): Promise<TodoItemType> => {
+const updateTodo = async (
+  id: string,
+  name: string
+): Promise<TodoItemType | undefined> => {
   const { rows } = await pool.query<TodoItemType, [string, string]>(
     "UPDATE todo SET name = $1 WHERE id = $2 RETURNING id::text, name",
     [name, id]
@@ -35,7 +38,9 @@ const updateTodo = async (id: string, name: string): Promise<TodoItemType> => {
   return rows[0];
 };
 
-const deleteTodo = async (id: string): Promise<Pick<TodoItemType, "id">> => {
+const deleteTodo = async (
+  id: string
+): Promise<Pick<TodoItemType, "id"> | undefined> => {
   const { rows } = await pool.query<Pick<TodoItemType, "id">, [string]>(
     "DELETE FROM todo WHERE id = $1 RETURNING id::text",
     [id]

--- a/backend/src/services/todoServices.ts
+++ b/backend/src/services/todoServices.ts
@@ -11,6 +11,14 @@ const listTodos = async (): Promise<TodoItemType[]> => {
   return rows;
 };
 
+const getTodo = async (id: string): Promise<TodoItemType | undefined> => {
+  const { rows } = await pool.query<TodoItemType, [string]>(
+    "SELECT id::text, name FROM todo WHERE id = $1",
+    [id]
+  );
+  return rows[0];
+};
+
 const createTodo = async (name: string): Promise<TodoItemType> => {
   const { rows } = await pool.query<TodoItemType, [string]>(
     "INSERT INTO todo (name) VALUES ($1) RETURNING id::text, name",
@@ -37,6 +45,7 @@ const deleteTodo = async (id: string): Promise<Pick<TodoItemType, "id">> => {
 
 export default {
   listTodos,
+  getTodo,
   createTodo,
   updateTodo,
   deleteTodo,

--- a/backend/tests/controllers/todoController.test.ts
+++ b/backend/tests/controllers/todoController.test.ts
@@ -37,7 +37,7 @@ describe("todoController", () => {
       });
     });
 
-    it("should pass error to next function if something wrong", async () => {
+    it("should pass error to next function if error is thrown from DAO", async () => {
       if (jest.isMockFunction(todoServices.listTodos)) {
         todoServices.listTodos.mockRejectedValueOnce(new Error("Test Error"));
       }
@@ -62,13 +62,25 @@ describe("todoController", () => {
       });
     });
 
-    it("should pass error to next function if something wrong", async () => {
+    it("should pass error to next function if error is thrown from DAO", async () => {
       if (jest.isMockFunction(todoServices.createTodo)) {
         todoServices.createTodo.mockRejectedValueOnce(new Error("Test Error"));
       }
       await todoController.createTodo(mockRequest, mockResponse, mockNext);
       expect(mockNext).toHaveBeenCalledWith(
         expect.objectContaining({ message: "Test Error" })
+      );
+    });
+
+    it("should pass error to next function if DAO returns undefined", async () => {
+      if (jest.isMockFunction(todoServices.createTodo)) {
+        todoServices.createTodo.mockResolvedValueOnce(undefined);
+      }
+      await todoController.createTodo(mockRequest, mockResponse, mockNext);
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Something went wrong when creating To-Do",
+        })
       );
     });
   });
@@ -87,13 +99,25 @@ describe("todoController", () => {
       });
     });
 
-    it("should pass error to next function if something wrong", async () => {
+    it("should pass error to next function if error is thrown from DAO", async () => {
       if (jest.isMockFunction(todoServices.updateTodo)) {
         todoServices.updateTodo.mockRejectedValueOnce(new Error("Test Error"));
       }
       await todoController.updateTodo(mockRequest, mockResponse, mockNext);
       expect(mockNext).toHaveBeenCalledWith(
         expect.objectContaining({ message: "Test Error" })
+      );
+    });
+
+    it("should pass error to next function if DAO returns undefined", async () => {
+      if (jest.isMockFunction(todoServices.updateTodo)) {
+        todoServices.updateTodo.mockResolvedValueOnce(undefined);
+      }
+      await todoController.updateTodo(mockRequest, mockResponse, mockNext);
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Something went wrong when updating To-Do",
+        })
       );
     });
   });
@@ -108,13 +132,25 @@ describe("todoController", () => {
       expect(mockResponse.json).toHaveBeenCalledWith({ id: "1" });
     });
 
-    it("should pass error to next function if something wrong", async () => {
+    it("should pass error to next function if error is thrown from DAO", async () => {
       if (jest.isMockFunction(todoServices.deleteTodo)) {
         todoServices.deleteTodo.mockRejectedValueOnce(new Error("Test Error"));
       }
       await todoController.deleteTodo(mockRequest, mockResponse, mockNext);
       expect(mockNext).toHaveBeenCalledWith(
         expect.objectContaining({ message: "Test Error" })
+      );
+    });
+
+    it("should pass error to next function if DAO returns undefined", async () => {
+      if (jest.isMockFunction(todoServices.deleteTodo)) {
+        todoServices.deleteTodo.mockResolvedValueOnce(undefined);
+      }
+      await todoController.deleteTodo(mockRequest, mockResponse, mockNext);
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Something went wrong when deleting To-Do",
+        })
       );
     });
   });

--- a/backend/tests/middlewares/todoValidator.test.ts
+++ b/backend/tests/middlewares/todoValidator.test.ts
@@ -1,6 +1,17 @@
 import type { Request, Response, NextFunction } from "express";
 import todoValidator from "../../src/middlewares/todoValidator";
 import validatorTester from "../../src/utils/validatorTester";
+import type TodoItemType from "../../src/types/TodoItemType";
+
+jest.mock("../../src/services/todoServices", () => {
+  const todoData: TodoItemType[] = [{ id: "1", name: "Test" }];
+  return {
+    __esModule: true,
+    default: {
+      getTodo: (id: string) => todoData.find((item) => item.id === id),
+    },
+  };
+});
 
 describe("todoValidator", () => {
   let mockRequest: Request;
@@ -17,61 +28,115 @@ describe("todoValidator", () => {
     mockNext = jest.fn();
   });
 
-  it("should respond 400 with error msg if creating To-Do with name missing", async () => {
-    mockRequest.body = {};
+  describe("createTodo", () => {
+    it("should respond 400 with error msg if creating To-Do with name missing", async () => {
+      mockRequest.body = {};
 
-    await validatorTester(
-      mockRequest,
-      mockResponse,
-      mockNext,
-      ...todoValidator.createTodo
-    );
+      await validatorTester(
+        mockRequest,
+        mockResponse,
+        mockNext,
+        ...todoValidator.createTodo
+      );
 
-    expect(mockResponse.status).toHaveBeenCalledWith(400);
-    expect(mockResponse.json).toHaveBeenCalledWith({
-      message: "name is required",
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: "name is required",
+      });
+    });
+
+    it("should proceed to next middleware if creating To-Do with name", async () => {
+      mockRequest.body = { name: "Test" };
+
+      await validatorTester(
+        mockRequest,
+        mockResponse,
+        mockNext,
+        ...todoValidator.createTodo
+      );
+
+      expect(mockNext).toHaveBeenCalledTimes(todoValidator.createTodo.length);
     });
   });
 
-  it("should proceed to next middleware if creating To-Do with name", async () => {
-    mockRequest.body = { name: "Test" };
+  describe("updateTodo", () => {
+    it("should respond 400 with error msg if updating To-Do with name missing", async () => {
+      mockRequest.params = { id: "NOT_EXIST" };
+      mockRequest.body = {};
 
-    await validatorTester(
-      mockRequest,
-      mockResponse,
-      mockNext,
-      ...todoValidator.createTodo
-    );
+      await validatorTester(
+        mockRequest,
+        mockResponse,
+        mockNext,
+        ...todoValidator.updateTodo
+      );
 
-    expect(mockNext).toHaveBeenCalledTimes(todoValidator.createTodo.length);
-  });
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: "name is required",
+      });
+    });
 
-  it("should respond 400 with error msg if updating To-Do with name missing", async () => {
-    mockRequest.body = {};
+    it("should respond 404 with error msg if updating To-Do with non-exist id", async () => {
+      mockRequest.params = { id: "NOT_EXIST" };
+      mockRequest.body = { name: "Test Update" };
 
-    await validatorTester(
-      mockRequest,
-      mockResponse,
-      mockNext,
-      ...todoValidator.updateTodo
-    );
+      await validatorTester(
+        mockRequest,
+        mockResponse,
+        mockNext,
+        ...todoValidator.updateTodo
+      );
 
-    expect(mockResponse.status).toHaveBeenCalledWith(400);
-    expect(mockResponse.json).toHaveBeenCalledWith({
-      message: "name is required",
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: "id 'NOT_EXIST' does not exist",
+      });
+    });
+
+    it("should proceed to next middleware if updating To-Do with valid id and name", async () => {
+      mockRequest.params = { id: "1" };
+      mockRequest.body = { name: "Test Update" };
+
+      await validatorTester(
+        mockRequest,
+        mockResponse,
+        mockNext,
+        ...todoValidator.updateTodo
+      );
+
+      expect(mockNext).toHaveBeenCalledTimes(todoValidator.updateTodo.length);
     });
   });
 
-  it("should proceed to next middleware if updating To-Do with name", async () => {
-    mockRequest.body = { name: "Test" };
+  describe("deleteTodo", () => {
+    it("should respond 404 with error msg if deleting To-Do with non-exist id", async () => {
+      mockRequest.params = { id: "NOT_EXIST" };
 
-    await validatorTester(
-      mockRequest,
-      mockResponse,
-      mockNext,
-      ...todoValidator.updateTodo
-    );
+      await validatorTester(
+        mockRequest,
+        mockResponse,
+        mockNext,
+        ...todoValidator.deleteTodo
+      );
 
-    expect(mockNext).toHaveBeenCalledTimes(todoValidator.updateTodo.length);
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        message: "id 'NOT_EXIST' does not exist",
+      });
+    });
+
+    it("should proceed to next middleware if deleting To-Do with valid id", async () => {
+      mockRequest.params = { id: "1" };
+
+      await validatorTester(
+        mockRequest,
+        mockResponse,
+        mockNext,
+        ...todoValidator.deleteTodo
+      );
+
+      expect(mockNext).toHaveBeenCalledTimes(todoValidator.deleteTodo.length);
+    });
   });
 });

--- a/backend/tests/routes/todoRoute.test.ts
+++ b/backend/tests/routes/todoRoute.test.ts
@@ -22,6 +22,10 @@ jest.mock("../../src/controllers/todoController", () => {
 });
 
 jest.mock("../../src/middlewares/todoValidator", () => {
+  const originalModule = jest.requireActual<
+    typeof import("../../src/middlewares/todoValidator")
+  >("../../src/middlewares/todoValidator");
+
   const makeMiddlewareMock = () =>
     jest.fn((req: Request, res: Response, next: NextFunction) => {
       next();
@@ -29,9 +33,15 @@ jest.mock("../../src/middlewares/todoValidator", () => {
   return {
     __esModule: true,
     default: {
-      createTodo: [makeMiddlewareMock()],
-      updateTodo: [makeMiddlewareMock()],
-      deleteTodo: [makeMiddlewareMock()],
+      createTodo: originalModule.default.createTodo.map((_) =>
+        makeMiddlewareMock()
+      ),
+      updateTodo: originalModule.default.updateTodo.map((_) =>
+        makeMiddlewareMock()
+      ),
+      deleteTodo: originalModule.default.deleteTodo.map((_) =>
+        makeMiddlewareMock()
+      ),
     },
   };
 });

--- a/backend/tests/routes/todoRoute.test.ts
+++ b/backend/tests/routes/todoRoute.test.ts
@@ -31,6 +31,7 @@ jest.mock("../../src/middlewares/todoValidator", () => {
     default: {
       createTodo: [makeMiddlewareMock()],
       updateTodo: [makeMiddlewareMock()],
+      deleteTodo: [makeMiddlewareMock()],
     },
   };
 });
@@ -81,6 +82,9 @@ describe("todoRoute", () => {
   it("should run all middlewares for DELETE /:id", async () => {
     await request(app).delete("/123");
 
+    todoValidator.deleteTodo.forEach((validator) => {
+      expect(validator).toHaveBeenCalled();
+    });
     expect(todoController.deleteTodo).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Add an additional validation logic to check for existence of `id`. This validation applies to `PUT /todo/:id` and `DELETE /todo/:id`. If attempting to update or delete by a non-exist `id`, status `404` will be returned.