### PR TITLE
refactor: rename list all todos api route

### DIFF
--- a/backend/src/routes/todoRoute.ts
+++ b/backend/src/routes/todoRoute.ts
@@ -4,7 +4,7 @@ import todoValidator from "../middlewares/todoValidator";
 
 const router = express.Router();
 
-router.get("/", todoController.listTodos);
+router.get("/all", todoController.listTodos);
 
 router.post("/", todoValidator.createTodo, todoController.createTodo);
 

--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -37,8 +37,8 @@ jest.mock("../src/services/todoService", () => {
 });
 
 describe("app", () => {
-  it("should return 200 with list of todos for GET /todo", async () => {
-    const response = await request(app).get("/todo");
+  it("should return 200 with list of todos for GET /todo/all", async () => {
+    const response = await request(app).get("/todo/all");
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ results: [{ id: "1", name: "Test" }] });
   });
@@ -76,7 +76,7 @@ describe("app", () => {
     if (jest.isMockFunction(todoService.listTodos)) {
       todoService.listTodos.mockRejectedValueOnce(new Error("Test Error"));
     }
-    const response = await request(app).get("/todo");
+    const response = await request(app).get("/todo/all");
     expect(response.status).toBe(500);
     expect(response.body).toEqual({ message: "Test Error" });
   });

--- a/backend/tests/routes/todoRoute.test.ts
+++ b/backend/tests/routes/todoRoute.test.ts
@@ -59,8 +59,8 @@ describe("todoRoute", () => {
     jest.clearAllMocks();
   });
 
-  it("should run all middlewares for GET /", async () => {
-    await request(app).get("/");
+  it("should run all middlewares for GET /all", async () => {
+    await request(app).get("/all");
 
     expect(todoController.listTodos).toHaveBeenCalled();
   });


### PR DESCRIPTION
Rename the existing `GET /todo` to `GET /todo/all` for better elaboration.