### PR TITLE
build: rename npm scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,8 +25,8 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc --project tsconfig.build.json",
-    "start": "cross-env NODE_ENV=production node \"dist/index.js\"",
-    "dev": "nodemon \"src/index.ts\"",
+    "serve": "cross-env NODE_ENV=production node \"dist/index.js\"",
+    "start": "nodemon \"src/index.ts\"",
     "test": "cross-env NODE_ENV=test jest"
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,4 +3,6 @@ import app from "./app";
 
 const port = 8080;
 
-app.listen(port);
+app.listen(port, () => {
+  console.log(`App listening on port ${port}`);
+});


### PR DESCRIPTION
Rename the npm scripts in order to match with the convention in frontend project.
- Rename the existing `dev` script to `start`, i.e. `npm run start` is for local development
- Rename the existing `start` script to `serve`, i.e. `npm run serve` is for serving a production build