### PR TITLE
feat: display server error info

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -3,6 +3,8 @@ import { Button, Flex, List, message, Modal, Skeleton, Typography } from "antd";
 import AddTodoForm from "./AddTodoForm";
 import EditTodoModal from "./EditTodoModal";
 import apiClient from "../network/apiClient";
+import { getApiErrorInfo } from "../utils/apiErrorUtils";
+import { formatApiErrorMessage } from "../utils/formatUtils";
 import type TodoItemType from "../types/TodoItemType";
 
 const { Title } = Typography;
@@ -43,6 +45,14 @@ const HomePage: React.FC = () => {
       const { results } = await apiClient.listTodos();
       setTodoData(results);
     } catch (error) {
+      const { status, message } = { ...getApiErrorInfo(error) };
+      const formatted = formatApiErrorMessage(
+        `Error encountered when getting all To-Dos`,
+        status,
+        message
+      );
+      showErrorMessage(formatted);
+      throw error;
     } finally {
       setLoading(false);
     }
@@ -54,7 +64,13 @@ const HomePage: React.FC = () => {
       showSuccessMessage(`"${name}" is added successfully`);
       reloadData();
     } catch (error) {
-      showErrorMessage(`Error encountered when adding "${name}"`);
+      const { status, message } = { ...getApiErrorInfo(error) };
+      const formatted = formatApiErrorMessage(
+        `Error encountered when adding "${name}"`,
+        status,
+        message
+      );
+      showErrorMessage(formatted);
       throw error;
     }
   }, []);
@@ -78,9 +94,13 @@ const HomePage: React.FC = () => {
         );
         reloadData();
       } catch (error) {
-        showErrorMessage(
-          `Error encountered when changing "${oldName}" to "${newName}"`
+        const { status, message } = { ...getApiErrorInfo(error) };
+        const formatted = formatApiErrorMessage(
+          `Error encountered when changing "${oldName}" to "${newName}"`,
+          status,
+          message
         );
+        showErrorMessage(formatted);
         throw error;
       }
     },
@@ -94,7 +114,13 @@ const HomePage: React.FC = () => {
       showSuccessMessage(`"${name}" is deleted successfully`);
       reloadData();
     } catch (error) {
-      showErrorMessage(`Error encountered when deleting "${name}"`);
+      const { status, message } = { ...getApiErrorInfo(error) };
+      const formatted = formatApiErrorMessage(
+        `Error encountered when deleting "${name}"`,
+        status,
+        message
+      );
+      showErrorMessage(formatted);
       throw error;
     }
   }, []);

--- a/frontend/src/utils/apiErrorUtils.ts
+++ b/frontend/src/utils/apiErrorUtils.ts
@@ -1,0 +1,13 @@
+import { isAxiosError } from "axios";
+
+type ErrorBody = { message: string };
+type ErrorInfo = { status?: number } & Partial<ErrorBody>;
+
+export const getApiErrorInfo = (error: any): ErrorInfo | undefined => {
+  if (isAxiosError<ErrorBody>(error)) {
+    const { status, data } = { ...error.response };
+    const { message } = { ...data };
+    return { status, message };
+  }
+  return undefined;
+};

--- a/frontend/src/utils/formatUtils.ts
+++ b/frontend/src/utils/formatUtils.ts
@@ -1,0 +1,14 @@
+export const formatApiErrorMessage = (
+  defaultMessage: string,
+  errorStatus: number | undefined,
+  errorMessage: string | undefined
+): string => {
+  let result = defaultMessage;
+  if (errorMessage) {
+    result = result.concat(": ", errorMessage);
+  }
+  if (errorStatus) {
+    result = result.concat(" ", `[${errorStatus}]`);
+  }
+  return result;
+};


### PR DESCRIPTION
Display the `message` and `status` of a failed API request on the UI.

**Example**
<img width="684" alt="Screenshot 2024-02-19 at 6 21 06 PM" src="https://github.com/ApplejackRabbit/todo-web-app/assets/140619457/75d28c1b-5962-4fa9-a730-11759a92d104">
