### PR TITLE
fix: sql order by behavior

### DIFF
--- a/backend/src/services/todoService.ts
+++ b/backend/src/services/todoService.ts
@@ -6,7 +6,7 @@ const pool = new Pool(dbConfig);
 
 const listTodos = async (): Promise<TodoItemType[]> => {
   const { rows } = await pool.query<TodoItemType>(
-    "SELECT id::text, name FROM todo ORDER BY id DESC"
+    "SELECT id::text, name FROM todo ORDER BY id::INT DESC"
   );
   return rows;
 };


### PR DESCRIPTION
Figured out that the current sql statement for `GET /todo/all` is ordering by `id` as string. Adding this fix should order as integer.