### PR TITLE
fix: error re-thrown issue

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -52,7 +52,6 @@ const HomePage: React.FC = () => {
         message
       );
       showErrorMessage(formatted);
-      throw error;
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Figured out that an error is mistakenly re-thrown in the `reload` function.